### PR TITLE
Fix overlay animation restart

### DIFF
--- a/script.js
+++ b/script.js
@@ -5,7 +5,7 @@ document.querySelectorAll('.btn').forEach(button => {
     const color = window.getComputedStyle(button).backgroundColor;
     overlay.style.backgroundColor = color;
 
-    overlay.style.animation = 'none';
+    overlay.classList.remove('fill');
     overlay.style.height = '0';
     // trigger reflow to restart animation
     void overlay.offsetWidth;


### PR DESCRIPTION
## Summary
- ensure `.fill` animation isn't overridden by removing the manual `animation` style
- reapply `.fill` class after a reflow to restart overlay animation

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6855119830448322972db84ed04b231f