### PR TITLE
Add temporary button clones on press

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,6 +1,31 @@
 const overlay = document.getElementById('overlay');
 
+let activeButton = null;
+
+function createClones(button) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'clone-wrapper';
+  for (let i = 0; i < 10; i++) {
+    const clone = button.cloneNode(true);
+    clone.disabled = true;
+    wrapper.appendChild(clone);
+  }
+  button.after(wrapper);
+  activeButton = {button, wrapper};
+}
+
+function removeClones() {
+  if (activeButton && activeButton.wrapper) {
+    activeButton.wrapper.remove();
+    activeButton = null;
+  }
+}
+
 document.querySelectorAll('.btn').forEach(button => {
+  button.addEventListener('mousedown', () => createClones(button));
+  button.addEventListener('mouseup', removeClones);
+  button.addEventListener('mouseleave', removeClones);
+
   button.addEventListener('click', () => {
     const color = window.getComputedStyle(button).backgroundColor;
     overlay.style.backgroundColor = color;
@@ -17,3 +42,5 @@ document.querySelectorAll('.btn').forEach(button => {
     }, 3000); // 2s animation + 1s pause
   });
 });
+
+document.addEventListener('mouseup', removeClones);

--- a/style.css
+++ b/style.css
@@ -12,6 +12,13 @@ body {
     display: flex;
     gap: 20px;
   }
+
+  .clone-wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 10px;
+  }
   
   .btn {
     padding: 12px 24px;


### PR DESCRIPTION
## Summary
- create 10 cloned buttons while a button is held down
- remove clones on mouse release
- style clone wrapper for stacked layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685513baba2c8322b1903a7850615295