### PR TITLE
Remove button cloning feature

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,31 +1,6 @@
 const overlay = document.getElementById('overlay');
 
-let activeButton = null;
-
-function createClones(button) {
-  const wrapper = document.createElement('div');
-  wrapper.className = 'clone-wrapper';
-  for (let i = 0; i < 10; i++) {
-    const clone = button.cloneNode(true);
-    clone.disabled = true;
-    wrapper.appendChild(clone);
-  }
-  button.after(wrapper);
-  activeButton = {button, wrapper};
-}
-
-function removeClones() {
-  if (activeButton && activeButton.wrapper) {
-    activeButton.wrapper.remove();
-    activeButton = null;
-  }
-}
-
 document.querySelectorAll('.btn').forEach(button => {
-  button.addEventListener('mousedown', () => createClones(button));
-  button.addEventListener('mouseup', removeClones);
-  button.addEventListener('mouseleave', removeClones);
-
   button.addEventListener('click', () => {
     const color = window.getComputedStyle(button).backgroundColor;
     overlay.style.backgroundColor = color;
@@ -42,5 +17,3 @@ document.querySelectorAll('.btn').forEach(button => {
     }, 3000); // 2s animation + 1s pause
   });
 });
-
-document.addEventListener('mouseup', removeClones);

--- a/style.css
+++ b/style.css
@@ -13,13 +13,6 @@ body {
     gap: 20px;
   }
 
-  .clone-wrapper {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-    margin-top: 10px;
-  }
-  
   .btn {
     padding: 12px 24px;
     border: none;


### PR DESCRIPTION
## Summary
- disable button cloning by removing clone logic
- clean up CSS rules for the unused `.clone-wrapper`

## Testing
- `npm test` *(fails: ENOENT no such file or directory 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6855634de790832290a4317970d2a9ad