### PR TITLE
Disable buttons during overlay animation

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,9 +1,14 @@
 const overlay = document.getElementById('overlay');
 
-document.querySelectorAll('.btn').forEach(button => {
+const buttons = document.querySelectorAll('.btn');
+
+buttons.forEach(button => {
   button.addEventListener('click', () => {
     const color = window.getComputedStyle(button).backgroundColor;
     overlay.style.backgroundColor = color;
+
+    // disable all buttons during the fill animation
+    buttons.forEach(btn => (btn.disabled = true));
 
     overlay.classList.remove('fill');
     overlay.style.height = '0';
@@ -14,6 +19,8 @@ document.querySelectorAll('.btn').forEach(button => {
     setTimeout(() => {
       overlay.classList.remove('fill');
       overlay.style.height = '0';
+      // re-enable buttons once animation completes
+      buttons.forEach(btn => (btn.disabled = false));
     }, 3000); // 2s animation + 1s pause
   });
 });

--- a/style.css
+++ b/style.css
@@ -26,6 +26,11 @@ body {
   .btn:active {
     transform: scale(0.95);
   }
+
+  .btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
   
   .red {
     background-color: #e74c3c;


### PR DESCRIPTION
## Summary
- disable all buttons while color fill is active
- add disabled button styles so user can't interrupt animation

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6855648929c48322a19e945dd09143b8