### PR TITLE
Add dripping paint effect

### DIFF
--- a/script.js
+++ b/script.js
@@ -2,29 +2,43 @@
 const overlay = document.getElementById('overlay');
 const buttons = document.querySelectorAll('.btn');
 
-// Kick off the fill on button click
+// Kick off the drip effect on button click
 buttons.forEach(button => {
   button.addEventListener('click', () => {
     const color = getComputedStyle(button).backgroundColor;
-    overlay.style.backgroundColor = color;
-
-    // Disable all buttons immediately
-    buttons.forEach(btn => btn.disabled = true);
-
-    // Restart the fill animation
-    overlay.classList.remove('fill');
-    overlay.style.height = '0';
-    // force reflow
-    void overlay.offsetWidth;
-    overlay.classList.add('fill');
+    startDrip(color);
   });
 });
 
-// When the fill animation ends, wait 1s, then reset and re-enable
-overlay.addEventListener('animationend', () => {
+function startDrip(color) {
+  // disable buttons during animation
+  buttons.forEach(btn => btn.disabled = true);
+
+  // clear previous drops
+  overlay.innerHTML = '';
+  overlay.style.backgroundColor = 'transparent';
+
+  const dropCount = 40;
+  const maxDelay = 1.5; // seconds
+
+  for (let i = 0; i < dropCount; i++) {
+    const drop = document.createElement('div');
+    const delay = Math.random() * maxDelay;
+    drop.classList.add('drop');
+    drop.style.backgroundColor = color;
+    drop.style.left = `${Math.random() * 100}%`;
+    drop.style.width = `${2 + Math.random() * 6}px`;
+    drop.style.setProperty('--delay', `${delay}s`);
+    overlay.appendChild(drop);
+  }
+
+  // once the drips have finished, show solid color then reset
   setTimeout(() => {
-    overlay.classList.remove('fill');
-    overlay.style.height = '0';
-    buttons.forEach(btn => btn.disabled = false);
-  }, 1000); // 1s pause after the 2s fill
-});
+    overlay.style.backgroundColor = color;
+    overlay.innerHTML = '';
+    setTimeout(() => {
+      overlay.style.backgroundColor = 'transparent';
+      buttons.forEach(btn => btn.disabled = false);
+    }, 1000); // hold color for a moment
+  }, (maxDelay + 2) * 1000);
+}

--- a/style.css
+++ b/style.css
@@ -42,16 +42,20 @@ body {
   top: 0;
   left: 0;
   width: 100%;
-  height: 0;
+  height: 100%;
   pointer-events: none;
   z-index: 1000;
+  overflow: hidden;
 }
 
-.fill {
-  animation: fill 2s forwards;
+.drop {
+  position: absolute;
+  top: 0;
+  height: 0;
+  animation: drip 2s forwards;
+  animation-delay: var(--delay, 0s);
 }
 
-@keyframes fill {
-  from { height: 0; }
-  to   { height: 100%; }
+@keyframes drip {
+  to { height: 100%; }
 }


### PR DESCRIPTION
## Summary
- implement a dripping paint effect that covers the screen
- style overlay to support drops

## Testing
- `node -v`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68557320d2948322a3aec2a0f67807bd